### PR TITLE
Add multilingual Municipio landing page

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+node_modules
+npm-debug.log
+Dockerfile
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:1.25-alpine
+
+RUN rm -rf /usr/share/nginx/html/*
+COPY public /usr/share/nginx/html
+
+EXPOSE 80
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 CMD wget -qO- http://127.0.0.1/ || exit 1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,54 @@
-# Municipality 16 Plus - Landing page
+# Municipio Landing Page
+
+A multilingual landing page for the Municipio board game and digital app, designed to echo the colourful look-and-feel of the Municipality 16+ materials. The site is built as a static bundle that can be served with Nginx and deployed via Docker Compose.
+
+## Features
+
+- 🌐 Four languages: English, Čeština, Latviešu and Slovenščina.
+- 🎲 Visuals inspired by the Municipio board-game box and mobile app colour palette.
+- 📱 Responsive layout that works on desktop, tablet and mobile viewports.
+- 🔗 Quick access buttons to the web application and Google Drive downloadables.
+- ⚙️ Lightweight vanilla JavaScript for instant translation switching and link management.
+
+## Project structure
+
+```
+public/
+  index.html          # Main landing page
+  assets/
+    css/styles.css    # Styling and layout
+    js/main.js        # Language switcher + copy
+    img/favicon.svg   # Favicon with Municipio palette
+Dockerfile            # Builds an Nginx image that serves /public
+docker-compose.yml    # Local orchestration helper
+```
+
+## Local development
+
+You can view the site with any static-file server. For example, using Python:
+
+```bash
+python3 -m http.server --directory public 8080
+```
+
+Then open <http://localhost:8080> in your browser.
+
+## Docker usage
+
+1. Build the image:
+   ```bash
+   docker compose build
+   ```
+2. Start the container:
+   ```bash
+   docker compose up
+   ```
+3. Visit <http://localhost:8080> to browse the landing page.
+
+## Customising links
+
+Edit `public/assets/js/main.js` and replace the placeholder values in the `links` object with the real URLs for the Municipio web application and Google Drive folder. The language strings can also be adjusted in the same file if you need to refine the translations.
+
+## Deployment
+
+The generated Nginx image serves the static files from `/usr/share/nginx/html`. Any static hosting solution (AWS S3, Netlify, GitHub Pages, your own Docker infrastructure, …) can use the contents of the `public` directory as-is.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  municipio:
+    build: .
+    ports:
+      - "8080:80"
+    restart: unless-stopped

--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -1,0 +1,504 @@
+:root {
+  --color-navy: #0c2b4d;
+  --color-blue: #1868a8;
+  --color-teal: #2db6ad;
+  --color-lime: #9be564;
+  --color-sand: #f6f0e6;
+  --color-cream: #fffaf3;
+  --color-sky: #7bd6ff;
+  --color-white: #ffffff;
+  --color-text: #14314f;
+  --shadow-soft: 0 24px 60px rgba(12, 43, 77, 0.22);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Poppins', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: var(--color-text);
+  background: var(--color-cream);
+  line-height: 1.6;
+}
+
+img,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.hero {
+  position: relative;
+  background: linear-gradient(160deg, #0c2b4d 0%, #11426f 45%, #2db6ad 100%);
+  color: var(--color-white);
+  padding-bottom: 6rem;
+  overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  opacity: 0.18;
+  background: radial-gradient(circle at center, rgba(123, 214, 255, 0.75), transparent 70%);
+}
+
+.hero::before {
+  width: 420px;
+  height: 420px;
+  top: -160px;
+  right: -120px;
+}
+
+.hero::after {
+  width: 520px;
+  height: 520px;
+  bottom: -260px;
+  left: -140px;
+}
+
+.top-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem clamp(1.5rem, 3vw, 3rem);
+  position: relative;
+  z-index: 1;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.brand strong {
+  display: block;
+  font-size: 1.1rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.brand small {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.76);
+}
+
+.brand-emblem {
+  width: 42px;
+  height: 42px;
+  background: linear-gradient(135deg, var(--color-lime), var(--color-teal));
+  color: var(--color-navy);
+  font-weight: 700;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.25);
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.language-selector select {
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: var(--color-white);
+  font-weight: 600;
+  padding: 0.45rem 1.4rem;
+  font-size: 0.95rem;
+  appearance: none;
+  outline: none;
+}
+
+.language-selector {
+  position: relative;
+}
+
+.language-selector::after {
+  content: '▾';
+  position: absolute;
+  right: 0.9rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+  background: linear-gradient(140deg, var(--color-lime), var(--color-teal));
+  color: var(--color-navy);
+  box-shadow: 0 18px 34px rgba(0, 0, 0, 0.25);
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 24px 42px rgba(0, 0, 0, 0.28);
+}
+
+.button.ghost {
+  background: transparent;
+  color: var(--color-white);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  box-shadow: none;
+}
+
+.button.ghost:hover,
+.button.ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.button.light {
+  background: var(--color-white);
+  color: var(--color-navy);
+  box-shadow: 0 10px 20px rgba(12, 43, 77, 0.22);
+}
+
+.button.outline {
+  background: transparent;
+  color: var(--color-white);
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  box-shadow: none;
+}
+
+.button.outline:hover,
+.button.outline:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.hero-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: center;
+  gap: clamp(2.5rem, 6vw, 5rem);
+  padding: 2rem 0 0;
+  position: relative;
+  z-index: 1;
+}
+
+.hero-text h1 {
+  font-size: clamp(2.4rem, 4vw + 1rem, 3.6rem);
+  line-height: 1.08;
+  margin: 0 0 1rem;
+}
+
+.hero-eyebrow {
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.76);
+  margin-bottom: 0.8rem;
+}
+
+.hero-lead {
+  font-size: 1.1rem;
+  max-width: 36ch;
+  margin-bottom: 2rem;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.hero-visual {
+  display: flex;
+  justify-content: center;
+}
+
+.hero-card {
+  background: var(--color-sand);
+  border-radius: 24px;
+  padding: 1.75rem;
+  width: min(320px, 90vw);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+}
+
+.card-top {
+  background: linear-gradient(135deg, var(--color-navy), var(--color-blue));
+  border-radius: 18px;
+  padding: 1.25rem;
+  color: var(--color-white);
+  text-transform: uppercase;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-align: center;
+}
+
+.city-grid {
+  margin-top: 1.4rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 74px;
+  height: 74px;
+  border-radius: 18px;
+  position: relative;
+  background: var(--color-white);
+  box-shadow: 0 18px 34px rgba(12, 43, 77, 0.14);
+}
+
+.pin::after {
+  content: '';
+  position: absolute;
+  bottom: -14px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  opacity: 0.6;
+  filter: blur(6px);
+}
+
+.pin.park {
+  background: linear-gradient(135deg, #9be564, #3bc785);
+}
+
+.pin.park::after {
+  background: rgba(59, 199, 133, 0.55);
+}
+
+.pin.lab {
+  background: linear-gradient(135deg, #7bd6ff, #2e9bea);
+}
+
+.pin.lab::after {
+  background: rgba(46, 155, 234, 0.45);
+}
+
+.pin.school {
+  background: linear-gradient(135deg, #ffc36e, #ff7d4d);
+}
+
+.pin.school::after {
+  background: rgba(255, 125, 77, 0.4);
+}
+
+.pin.hub {
+  background: linear-gradient(135deg, #fba6d1, #e8518f);
+}
+
+.pin.hub::after {
+  background: rgba(232, 81, 143, 0.45);
+}
+
+.pin.house {
+  background: linear-gradient(135deg, #b3b2ff, #6463ff);
+}
+
+.pin.house::after {
+  background: rgba(100, 99, 255, 0.42);
+}
+
+.pin.library {
+  background: linear-gradient(135deg, #ffe27d, #ffd447);
+}
+
+.pin.library::after {
+  background: rgba(255, 212, 71, 0.42);
+}
+
+.section {
+  padding: clamp(4rem, 8vw, 6rem) 0;
+}
+
+.section.alt {
+  background: var(--color-white);
+}
+
+.section.highlight {
+  background: linear-gradient(145deg, var(--color-blue), var(--color-teal));
+  color: var(--color-white);
+}
+
+.section h2 {
+  font-size: clamp(2rem, 2vw + 1.4rem, 2.6rem);
+  margin-bottom: 1rem;
+}
+
+.section p {
+  margin-bottom: 1.5rem;
+  font-size: 1.05rem;
+}
+
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.75rem;
+  margin-top: 2.5rem;
+}
+
+.pillars article {
+  background: var(--color-white);
+  border-radius: 18px;
+  padding: 1.8rem;
+  box-shadow: 0 22px 40px rgba(12, 43, 77, 0.12);
+}
+
+.section.alt .pillars article {
+  background: var(--color-cream);
+}
+
+.section-header {
+  max-width: 620px;
+}
+
+.steps {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2.5rem;
+}
+
+.step {
+  background: var(--color-cream);
+  border-radius: 18px;
+  padding: 1.8rem;
+  border: 2px solid rgba(12, 43, 77, 0.08);
+  position: relative;
+  overflow: hidden;
+}
+
+.step-number {
+  position: absolute;
+  top: 1.2rem;
+  right: 1.4rem;
+  font-size: 3rem;
+  font-weight: 700;
+  color: rgba(12, 43, 77, 0.08);
+}
+
+.highlight .cta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 2rem;
+}
+
+.cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.footer {
+  background: #081c31;
+  color: rgba(255, 255, 255, 0.82);
+  padding: 2.5rem 0;
+}
+
+.footer-content {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.footer-links {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.footer a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.footer a:hover,
+.footer a:focus-visible {
+  text-decoration: underline;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .top-nav {
+    flex-direction: column;
+    gap: 1.25rem;
+    align-items: flex-start;
+  }
+
+  .nav-actions {
+    width: 100%;
+    justify-content: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .hero {
+    padding-bottom: 4rem;
+  }
+
+  .hero-card {
+    margin-top: 1rem;
+  }
+
+  .footer-content {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/public/assets/img/favicon.svg
+++ b/public/assets/img/favicon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#2db6ad" />
+      <stop offset="100%" stop-color="#9be564" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#0c2b4d" />
+  <path
+    d="M18 46V18h14c8.2 0 14 4.8 14 12.9 0 8.4-5.8 15.1-14.7 15.1H18zm14-8.2c4.4 0 7.3-2.8 7.3-7.2 0-4.2-2.7-6.6-7.5-6.6H25v13.8h7z"
+    fill="url(#g)"
+  />
+</svg>

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -1,0 +1,248 @@
+const links = {
+  app: 'https://example.com/app',
+  downloads: 'https://drive.google.com',
+  contact: 'mailto:info@municipio.eu',
+};
+
+const translations = {
+  en: {
+    tagline: 'Co-create your city',
+    heroEyebrow: 'Play · Learn · Change',
+    heroTitle: 'Municipio empowers young people to redesign their neighbourhoods',
+    heroLead:
+      'Municipio is a board game and digital toolkit that helps schools and youth organisations explore civic challenges, design inclusive solutions, and collaborate with their communities.',
+    heroAppLink: 'Open the web application',
+    heroDownloadLink: 'Download materials',
+    aboutTitle: 'About the project',
+    aboutText:
+      'Municipio combines playful learning with real-world impact. The Municipality 16+ partnership co-created the game with educators, municipalities, and young changemakers across Europe to make civic participation tangible, collaborative, and fun.',
+    pillarOneTitle: 'Game-based learning',
+    pillarOneText:
+      'Use storytelling, missions, and role cards inspired by the Municipio board game to explore how cities function and who shapes them.',
+    pillarTwoTitle: 'Digital toolkit',
+    pillarTwoText:
+      'Access a responsive web application with challenge cards, facilitators’ guides, and ready-to-use session plans for hybrid workshops.',
+    pillarThreeTitle: 'Community impact',
+    pillarThreeText:
+      'Prototype solutions for local issues together with students, teachers, and municipal leaders, and keep the momentum with downloadable resources.',
+    howTitle: 'How Municipio sessions work',
+    howIntro:
+      'Each activity is designed to mirror the colourful energy of the Municipio universe—blending the board game aesthetic with digital-first collaboration.',
+    stepOneTitle: 'Discover',
+    stepOneText: 'Set the scene with the game board, place pins around the city, and identify community needs through playful scenarios.',
+    stepTwoTitle: 'Design',
+    stepTwoText: 'Use the web application to unlock missions, brainstorm inclusive ideas, and iterate on prototypes with rapid feedback.',
+    stepThreeTitle: 'Activate',
+    stepThreeText: 'Share action plans with local partners, download handouts, and launch real initiatives in your town or school.',
+    ctaTitle: 'Ready to bring Municipio to your community?',
+    ctaText: 'Start with the digital app or download the facilitation toolkit to run your own Municipio lab.',
+    ctaAppLink: 'Launch the app',
+    ctaDownloadLink: 'Get the download pack',
+    footerText: 'A Municipality 16+ collaboration powered by nvias.org and partners across Europe.',
+    footerAppLink: 'Municipio web application',
+    footerDownloadLink: 'Downloadable resources',
+    footerContactLink: 'Contact the team',
+  },
+  cs: {
+    tagline: 'Spoluvytvářej své město',
+    heroEyebrow: 'Hraj · Uč se · Měň',
+    heroTitle: 'Municipio dává mladým lidem sílu přetvářet své okolí',
+    heroLead:
+      'Municipio je desková hra a digitální nástroje, které školám i organizacím práce s mládeží pomáhají zkoumat občanské výzvy, navrhovat inkluzivní řešení a spolupracovat s komunitou.',
+    heroAppLink: 'Otevřít webovou aplikaci',
+    heroDownloadLink: 'Stáhnout materiály',
+    aboutTitle: 'O projektu',
+    aboutText:
+      'Municipio propojuje hravé učení se skutečným dopadem. Partnerství Municipality 16+ vytvořilo hru společně s učiteli, městy a mladými inovátory po celé Evropě, aby byla občanská participace hmatatelná, spolupracující a zábavná.',
+    pillarOneTitle: 'Učení hrou',
+    pillarOneText:
+      'Vyprávějte příběhy, plňte mise a používejte role inspirované deskovou hrou Municipio, abyste lépe pochopili, jak města fungují a kdo je utváří.',
+    pillarTwoTitle: 'Digitální balíček',
+    pillarTwoText:
+      'Získejte responzivní webovou aplikaci s kartami výzev, metodikami a hotovými scénáři pro hybridní workshopy.',
+    pillarThreeTitle: 'Dopad na komunitu',
+    pillarThreeText:
+      'Společně se studenty, učiteli a zástupci města prototypujte řešení místních problémů a pokračujte díky dostupným podkladům.',
+    howTitle: 'Jak probíhá setkání Municipio',
+    howIntro:
+      'Každá aktivita navazuje na energii barevného světa Municipio – propojuje estetiku deskové hry s digitální spoluprací.',
+    stepOneTitle: 'Objevuj',
+    stepOneText: 'Připrav herní plán, rozmísti piny po městě a pomocí hravých scénářů pojmenuj potřeby komunity.',
+    stepTwoTitle: 'Navrhuj',
+    stepTwoText: 'V aplikaci odemykej mise, vymýšlej inkluzivní nápady a rychle je prototypuj díky zpětné vazbě.',
+    stepThreeTitle: 'Aktivuj',
+    stepThreeText: 'Sdílej akční plány s lokálními partnery, stahuj podklady a spouštěj reálné iniciativy ve škole i ve městě.',
+    ctaTitle: 'Připraveni přinést Municipio do své komunity?',
+    ctaText: 'Začni digitální aplikací nebo si stáhni metodický balíček a zorganizuj vlastní Municipio lab.',
+    ctaAppLink: 'Spustit aplikaci',
+    ctaDownloadLink: 'Získat balíček ke stažení',
+    footerText: 'Spolupráce Municipality 16+ za podpory nvias.org a partnerů po celé Evropě.',
+    footerAppLink: 'Webová aplikace Municipio',
+    footerDownloadLink: 'Materiály ke stažení',
+    footerContactLink: 'Kontaktujte tým',
+  },
+  lv: {
+    tagline: 'Līdzradī savu pilsētu',
+    heroEyebrow: 'Spēlē · Mācies · Pārveido',
+    heroTitle: 'Municipio iedrošina jauniešus pārveidot savu apkārtni',
+    heroLead:
+      'Municipio ir galda spēle un digitāls rīkkopums, kas palīdz skolām un jaunatnes organizācijām pētīt pilsoniskos izaicinājumus, veidot iekļaujošus risinājumus un sadarboties ar kopienām.',
+    heroAppLink: 'Atvērt tīmekļa lietotni',
+    heroDownloadLink: 'Lejupielādēt materiālus',
+    aboutTitle: 'Par projektu',
+    aboutText:
+      'Municipio apvieno rotaļīgu mācīšanos ar reālu ietekmi. Municipality 16+ partnerība kopā ar pedagogiem, pašvaldībām un jaunajiem līderiem visā Eiropā radīja spēli, kas padara pilsonisko līdzdalību taustāmu, sadarbības pilnu un aizraujošu.',
+    pillarOneTitle: 'Spēļmācība',
+    pillarOneText:
+      'Izmanto stāstniecību, misijas un lomu kārtis, ko iedvesmojusi Municipio galda spēle, lai izprastu pilsētas darbību un tās veidotājus.',
+    pillarTwoTitle: 'Digitālie rīki',
+    pillarTwoText:
+      'Piekļūsti atsaucīgai tīmekļa lietotnei ar izaicinājumu kartītēm, vadlīnijām un gataviem nodarbību scenārijiem hibrīddarbnīcām.',
+    pillarThreeTitle: 'Kopienas ietekme',
+    pillarThreeText:
+      'Kopā ar skolēniem, skolotājiem un pašvaldībām prototipē risinājumus vietējiem jautājumiem un uzturi virzību ar lejupielādējamiem resursiem.',
+    howTitle: 'Kā norisinās Municipio sesijas',
+    howIntro:
+      'Katra aktivitāte iemieso krāsaino Municipio pasauli – apvienojot galda spēles estētiku ar digitālo sadarbību.',
+    stepOneTitle: 'Atklāj',
+    stepOneText: 'Izvieto spēles laukumu, novieto atzīmes pilsētā un rotaļīgā veidā apzinies kopienas vajadzības.',
+    stepTwoTitle: 'Veido',
+    stepTwoText: 'Lietotnē atslēdz misijas, ģenerē iekļaujošas idejas un ātri tās pārbaudi ar atgriezenisko saiti.',
+    stepThreeTitle: 'Iedaribini',
+    stepThreeText: 'Dalies ar rīcības plāniem, lejupielādē izdales materiālus un uzsāc reālas iniciatīvas savā pilsētā vai skolā.',
+    ctaTitle: 'Gatavi ieviest Municipio savā kopienā?',
+    ctaText: 'Sāc ar digitālo lietotni vai lejupielādē rīkkopu, lai vadītu savu Municipio darbnīcu.',
+    ctaAppLink: 'Palaist lietotni',
+    ctaDownloadLink: 'Saņemt lejupielādes komplektu',
+    footerText: 'Municipality 16+ sadarbība ar nvias.org un partneriem visā Eiropā.',
+    footerAppLink: 'Municipio tīmekļa lietotne',
+    footerDownloadLink: 'Resursi lejupielādei',
+    footerContactLink: 'Sazinies ar komandu',
+  },
+  sl: {
+    tagline: 'Sooblikuj svoje mesto',
+    heroEyebrow: 'Igraj · Uči se · Spreminjaj',
+    heroTitle: 'Municipio mladim daje orodja, da preoblikujejo svojo skupnost',
+    heroLead:
+      'Municipio je namizna igra in digitalni komplet orodij, ki šolam ter mladinskim organizacijam pomaga raziskovati družbene izzive, soustvarjati vključujoče rešitve in graditi partnerstva v lokalnem okolju.',
+    heroAppLink: 'Odpri spletno aplikacijo',
+    heroDownloadLink: 'Prenesi gradiva',
+    aboutTitle: 'O projektu',
+    aboutText:
+      'Municipio povezuje igrivo učenje z resničnim vplivom. Partnerstvo Municipality 16+ je skupaj z učitelji, občinami in mladimi ustvarjalci po vsej Evropi zasnovalo igro, ki omogoča oprijemljivo, sodelovalno in zabavno državljansko udejstvovanje.',
+    pillarOneTitle: 'Učenje skozi igro',
+    pillarOneText:
+      'Uporabite pripovedovanje zgodb, misije in vloge, ki jih navdihuje namizna igra Municipio, ter spoznajte, kako mesta delujejo in kdo jih oblikuje.',
+    pillarTwoTitle: 'Digitalni komplet',
+    pillarTwoText:
+      'Dostopajte do odzivne spletne aplikacije z izzivnimi karticami, vodniki za facilitatorje in pripravljenimi načrti delavnic.',
+    pillarThreeTitle: 'Vpliv na skupnost',
+    pillarThreeText:
+      'Skupaj z učenci, mentorji in predstavniki občin prototipirajte rešitve za lokalne izzive in nadaljujte delo s podporo prenesenih gradiv.',
+    howTitle: 'Kako potekajo srečanja Municipio',
+    howIntro:
+      'Vsaka aktivnost odraža barvito estetiko sveta Municipio – združuje videz namizne igre in digitalno sodelovanje.',
+    stepOneTitle: 'Odkrij',
+    stepOneText: 'Pripravite igralno ploščo, razporedite označevalce po mestu in skozi igrive scenarije spoznajte potrebe skupnosti.',
+    stepTwoTitle: 'Oblikuj',
+    stepTwoText: 'V spletni aplikaciji odklenite misije, soustvarjajte vključujoče ideje in jih hitro izpopolnite s povratnimi informacijami.',
+    stepThreeTitle: 'Oživi',
+    stepThreeText: 'Delite akcijske načrte z lokalnimi partnerji, prenesite gradiva in začnite resnične pobude v šoli ali mestu.',
+    ctaTitle: 'Ste pripravljeni prinesti Municipio v svojo skupnost?',
+    ctaText: 'Začnite s spletno aplikacijo ali prenesite paket za vodenje lastnega Municipio laboratorija.',
+    ctaAppLink: 'Zaženi aplikacijo',
+    ctaDownloadLink: 'Prenesi paket gradiv',
+    footerText: 'Partnerstvo Municipality 16+ v sodelovanju z nvias.org in partnerji po Evropi.',
+    footerAppLink: 'Spletna aplikacija Municipio',
+    footerDownloadLink: 'Gradiva za prenos',
+    footerContactLink: 'Kontaktiraj ekipo',
+  },
+};
+
+const textElements = {
+  tagline: document.getElementById('tagline'),
+  heroEyebrow: document.getElementById('heroEyebrow'),
+  heroTitle: document.getElementById('heroTitle'),
+  heroLead: document.getElementById('heroLead'),
+  heroAppLink: document.getElementById('heroAppLink'),
+  heroDownloadLink: document.getElementById('heroDownloadLink'),
+  aboutTitle: document.getElementById('aboutTitle'),
+  aboutText: document.getElementById('aboutText'),
+  pillarOneTitle: document.getElementById('pillarOneTitle'),
+  pillarOneText: document.getElementById('pillarOneText'),
+  pillarTwoTitle: document.getElementById('pillarTwoTitle'),
+  pillarTwoText: document.getElementById('pillarTwoText'),
+  pillarThreeTitle: document.getElementById('pillarThreeTitle'),
+  pillarThreeText: document.getElementById('pillarThreeText'),
+  howTitle: document.getElementById('howTitle'),
+  howIntro: document.getElementById('howIntro'),
+  stepOneTitle: document.getElementById('stepOneTitle'),
+  stepOneText: document.getElementById('stepOneText'),
+  stepTwoTitle: document.getElementById('stepTwoTitle'),
+  stepTwoText: document.getElementById('stepTwoText'),
+  stepThreeTitle: document.getElementById('stepThreeTitle'),
+  stepThreeText: document.getElementById('stepThreeText'),
+  ctaTitle: document.getElementById('ctaTitle'),
+  ctaText: document.getElementById('ctaText'),
+  ctaAppLink: document.getElementById('ctaAppLink'),
+  ctaDownloadLink: document.getElementById('ctaDownloadLink'),
+  footerText: document.getElementById('footerText'),
+  footerAppLink: document.getElementById('footerAppLink'),
+  footerDownloadLink: document.getElementById('footerDownloadLink'),
+  footerContactLink: document.getElementById('footerContactLink'),
+};
+
+const linkElements = [
+  document.getElementById('navAppLink'),
+  document.getElementById('navDownloadLink'),
+  document.getElementById('heroAppLink'),
+  document.getElementById('heroDownloadLink'),
+  document.getElementById('ctaAppLink'),
+  document.getElementById('ctaDownloadLink'),
+  document.getElementById('footerAppLink'),
+  document.getElementById('footerDownloadLink'),
+  document.getElementById('footerContactLink'),
+];
+
+const updateLanguage = (language) => {
+  const copy = translations[language] ?? translations.en;
+  Object.entries(textElements).forEach(([key, element]) => {
+    if (element && copy[key]) {
+      element.textContent = copy[key];
+    }
+  });
+};
+
+const applyLinks = () => {
+  linkElements.forEach((element) => {
+    if (!element) return;
+    const id = element.id.toLowerCase();
+    if (id.includes('app')) {
+      element.href = links.app;
+    } else if (id.includes('download')) {
+      element.href = links.downloads;
+    } else if (id.includes('contact')) {
+      element.href = links.contact;
+    }
+  });
+};
+
+const languageSwitcher = document.getElementById('language-switcher');
+
+languageSwitcher.addEventListener('change', (event) => {
+  const selected = event.target.value;
+  updateLanguage(selected);
+  localStorage.setItem('municipio-lang', selected);
+  document.documentElement.lang = selected;
+});
+
+const init = () => {
+  applyLinks();
+  const stored = localStorage.getItem('municipio-lang');
+  const initial = stored && translations[stored] ? stored : 'en';
+  languageSwitcher.value = initial;
+  updateLanguage(initial);
+  document.documentElement.lang = initial;
+};
+
+document.addEventListener('DOMContentLoaded', init);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Municipio – Co-create Your City</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="assets/css/styles.css" />
+    <link rel="icon" href="assets/img/favicon.svg" type="image/svg+xml" />
+  </head>
+  <body>
+    <header class="hero">
+      <nav class="top-nav">
+        <div class="brand">
+          <span class="brand-emblem">M</span>
+          <div>
+            <strong>Municipio</strong>
+            <small id="tagline"></small>
+          </div>
+        </div>
+        <div class="nav-actions">
+          <label class="language-selector">
+            <span class="sr-only" id="language-label">Language</span>
+            <select id="language-switcher" aria-labelledby="language-label">
+              <option value="en">English</option>
+              <option value="cs">Čeština</option>
+              <option value="lv">Latviešu</option>
+              <option value="sl">Slovenščina</option>
+            </select>
+          </label>
+          <a class="button ghost" id="navAppLink" href="https://example.com/app" target="_blank" rel="noopener">App</a>
+          <a class="button" id="navDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener">Downloads</a>
+        </div>
+      </nav>
+
+      <div class="hero-content container">
+        <div class="hero-text">
+          <p class="hero-eyebrow" id="heroEyebrow"></p>
+          <h1 id="heroTitle"></h1>
+          <p class="hero-lead" id="heroLead"></p>
+          <div class="hero-actions">
+            <a class="button" id="heroAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a>
+            <a class="button ghost" id="heroDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a>
+          </div>
+        </div>
+        <div class="hero-visual" aria-hidden="true">
+          <div class="hero-card">
+            <div class="card-top">
+              <span class="card-title">Municipio</span>
+              <span class="card-subtitle">Play | Learn | Change</span>
+            </div>
+            <div class="city-grid">
+              <span class="pin park"></span>
+              <span class="pin lab"></span>
+              <span class="pin school"></span>
+              <span class="pin hub"></span>
+              <span class="pin house"></span>
+              <span class="pin library"></span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <main>
+      <section class="section" id="about">
+        <div class="container">
+          <h2 id="aboutTitle"></h2>
+          <p id="aboutText"></p>
+          <div class="pillars">
+            <article>
+              <h3 id="pillarOneTitle"></h3>
+              <p id="pillarOneText"></p>
+            </article>
+            <article>
+              <h3 id="pillarTwoTitle"></h3>
+              <p id="pillarTwoText"></p>
+            </article>
+            <article>
+              <h3 id="pillarThreeTitle"></h3>
+              <p id="pillarThreeText"></p>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <section class="section alt" id="how">
+        <div class="container">
+          <div class="section-header">
+            <h2 id="howTitle"></h2>
+            <p id="howIntro"></p>
+          </div>
+          <div class="steps">
+            <div class="step">
+              <span class="step-number">1</span>
+              <h3 id="stepOneTitle"></h3>
+              <p id="stepOneText"></p>
+            </div>
+            <div class="step">
+              <span class="step-number">2</span>
+              <h3 id="stepTwoTitle"></h3>
+              <p id="stepTwoText"></p>
+            </div>
+            <div class="step">
+              <span class="step-number">3</span>
+              <h3 id="stepThreeTitle"></h3>
+              <p id="stepThreeText"></p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="section highlight" id="cta">
+        <div class="container cta">
+          <div>
+            <h2 id="ctaTitle"></h2>
+            <p id="ctaText"></p>
+          </div>
+          <div class="cta-actions">
+            <a class="button light" id="ctaAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a>
+            <a class="button outline" id="ctaDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <div class="container footer-content">
+        <div>
+          <strong>Municipio</strong>
+          <p id="footerText"></p>
+        </div>
+        <ul class="footer-links">
+          <li><a id="footerAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a></li>
+          <li><a id="footerDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a></li>
+          <li><a id="footerContactLink" href="mailto:info@municipio.eu"></a></li>
+        </ul>
+      </div>
+    </footer>
+
+    <script src="assets/js/main.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a colourful Municipio landing page with hero, project sections, and CTA content in four languages
- add styling, favicon, and translation logic inspired by the board-game look and feel
- provide Docker and Docker Compose setup for serving the static site via Nginx

## Testing
- python3 -m http.server --directory public 8080

------
https://chatgpt.com/codex/tasks/task_e_68e2d27fb0c08329b331a72fcd0ff362