### PR TITLE
Replace hero gradient with m16background.png

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -36,7 +36,7 @@ svg {
 
 .hero {
   position: relative;
-  background: linear-gradient(160deg, #0c2b4d 0%, #11426f 45%, #2db6ad 100%);
+  background: url('/assets/img/m16background.png') center/cover no-repeat;
   color: var(--color-white);
   padding-bottom: 6rem;
   overflow: hidden;


### PR DESCRIPTION
### Motivation
- Replace the blue-green gradient hero background with the provided `m16background.png` image to align the landing page with the updated visual design.
- Keep the existing hero layout and decorative overlays so component layout and accessibility remain unchanged.

### Description
- Update the `.hero` background property in `public/assets/css/styles.css` from the gradient to `url('/assets/img/m16background.png') center/cover no-repeat`.
- Preserve the `.hero::before` and `.hero::after` radial overlays and all other hero styles.

### Testing
- Served the site with `python -m http.server 8000` and verified the page was reachable.
- Ran a Playwright script to load `http://127.0.0.1:8000/` and capture a screenshot to `artifacts/landingpage-background.png`, which completed successfully.
- No unit or integration tests were applicable for this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610ee8352c832998a83a6c7b07b051)