### PR TITLE
Add GitHub Actions workflow to build and publish Docker image to GHCR

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,40 @@
+name: Build and publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}


### PR DESCRIPTION
### Motivation

- Provide an automated CI workflow to build the project Docker image and publish it to GitHub Container Registry (GHCR) on pushes to `main` or via manual dispatch.  
- Ensure images are tagged with both `:latest` and the commit SHA for traceability.  

### Description

- Add a new workflow file at `.github/workflows/docker-publish.yml` that runs on `push` to `main` and `workflow_dispatch`.  
- Use `actions/checkout@v4`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6` to build and push the image.  
- Authenticate to `ghcr.io` using `GITHUB_TOKEN` and set permissions `contents: read` and `packages: write`.  
- Publish image tags `ghcr.io/${{ github.repository }}:latest` and `ghcr.io/${{ github.repository }}:${{ github.sha }}` and include OCI labels for source and revision.  

### Testing

- No automated tests were executed as this is a workflow-only change.  
- The workflow is configured to run on `push` to `main` and can be triggered manually via `workflow_dispatch`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69650fa0475c8329ae333a4dd6d09e1a)