### PR TITLE
Remove hero pin rectangles and cleanup related styles/content

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -46,23 +46,19 @@ svg {
 .hero::after {
   content: '';
   position: absolute;
-  border-radius: 50%;
-  opacity: 0.18;
-  background: radial-gradient(circle at center, rgba(123, 214, 255, 0.75), transparent 70%);
+  inset: 0;
+  z-index: 0;
 }
 
 .hero::before {
-  width: 420px;
-  height: 420px;
-  top: -160px;
-  right: -120px;
+  background: rgba(6, 18, 33, 0.55);
 }
 
 .hero::after {
-  width: 520px;
-  height: 520px;
-  bottom: -260px;
-  left: -140px;
+  background:
+    radial-gradient(circle at top right, rgba(123, 214, 255, 0.45), transparent 60%),
+    radial-gradient(circle at bottom left, rgba(123, 214, 255, 0.35), transparent 65%);
+  opacity: 0.5;
 }
 
 .top-nav {
@@ -81,31 +77,10 @@ svg {
   font-weight: 600;
 }
 
-.brand strong {
-  display: block;
-  font-size: 1.1rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.brand small {
-  display: block;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(255, 255, 255, 0.76);
-}
-
-.brand-emblem {
-  width: 42px;
-  height: 42px;
-  background: linear-gradient(135deg, var(--color-lime), var(--color-teal));
-  color: var(--color-navy);
-  font-weight: 700;
-  border-radius: 12px;
-  display: grid;
-  place-items: center;
-  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.25);
+.brand-logo {
+  height: 64px;
+  width: auto;
+  filter: drop-shadow(0 10px 18px rgba(0, 0, 0, 0.35));
 }
 
 .nav-actions {
@@ -232,108 +207,6 @@ svg {
   gap: 1rem;
 }
 
-.hero-visual {
-  display: flex;
-  justify-content: center;
-}
-
-.hero-card {
-  background: var(--color-sand);
-  border-radius: 24px;
-  padding: 1.75rem;
-  width: min(320px, 90vw);
-  box-shadow: var(--shadow-soft);
-  position: relative;
-}
-
-.card-top {
-  background: linear-gradient(135deg, var(--color-navy), var(--color-blue));
-  border-radius: 18px;
-  padding: 1.25rem;
-  color: var(--color-white);
-  text-transform: uppercase;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-align: center;
-}
-
-.city-grid {
-  margin-top: 1.4rem;
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1.25rem;
-}
-
-.pin {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 74px;
-  height: 74px;
-  border-radius: 18px;
-  position: relative;
-  background: var(--color-white);
-  box-shadow: 0 18px 34px rgba(12, 43, 77, 0.14);
-}
-
-.pin::after {
-  content: '';
-  position: absolute;
-  bottom: -14px;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  opacity: 0.6;
-  filter: blur(6px);
-}
-
-.pin.park {
-  background: linear-gradient(135deg, #9be564, #3bc785);
-}
-
-.pin.park::after {
-  background: rgba(59, 199, 133, 0.55);
-}
-
-.pin.lab {
-  background: linear-gradient(135deg, #7bd6ff, #2e9bea);
-}
-
-.pin.lab::after {
-  background: rgba(46, 155, 234, 0.45);
-}
-
-.pin.school {
-  background: linear-gradient(135deg, #ffc36e, #ff7d4d);
-}
-
-.pin.school::after {
-  background: rgba(255, 125, 77, 0.4);
-}
-
-.pin.hub {
-  background: linear-gradient(135deg, #fba6d1, #e8518f);
-}
-
-.pin.hub::after {
-  background: rgba(232, 81, 143, 0.45);
-}
-
-.pin.house {
-  background: linear-gradient(135deg, #b3b2ff, #6463ff);
-}
-
-.pin.house::after {
-  background: rgba(100, 99, 255, 0.42);
-}
-
-.pin.library {
-  background: linear-gradient(135deg, #ffe27d, #ffd447);
-}
-
-.pin.library::after {
-  background: rgba(255, 212, 71, 0.42);
-}
 
 .section {
   padding: clamp(4rem, 8vw, 6rem) 0;

--- a/public/assets/data/content.json
+++ b/public/assets/data/content.json
@@ -1,31 +1,36 @@
 {
   "links": {
     "app": "app.municipality16plus.eu",
-    "downloads": "https://drive.google.com",
     "contact": "mailto:info@municipio.eu"
   },
   "languages": [
-    { "code": "en", "label": "English" },
-    { "code": "cs", "label": "Čeština" },
-    { "code": "lv", "label": "Latviešu" },
-    { "code": "sl", "label": "Slovenščina" }
+    {
+      "code": "en",
+      "label": "English"
+    },
+    {
+      "code": "cs",
+      "label": "Čeština"
+    },
+    {
+      "code": "lv",
+      "label": "Latviešu"
+    },
+    {
+      "code": "sl",
+      "label": "Slovenščina"
+    }
   ],
   "translations": {
     "en": {
       "pageTitle": "Municipio – Co-create Your City",
-      "brandName": "Municipio",
       "footerBrandName": "Municipio",
-      "cardTitle": "Municipio",
-      "cardSubtitle": "Play | Learn | Change",
       "languageLabel": "Language",
       "navAppLink": "App",
-      "navDownloadLink": "Downloads",
-      "tagline": "Co-create your city",
       "heroEyebrow": "Play · Learn · Change",
       "heroTitle": "Municipio empowers young people to redesign their neighbourhoods",
       "heroLead": "Municipio is a board game and digital toolkit that helps schools and youth organisations explore civic challenges, design inclusive solutions, and collaborate with their communities.",
       "heroAppLink": "Open the web application",
-      "heroDownloadLink": "Download materials",
       "aboutTitle": "About the project",
       "aboutText": "Municipio combines playful learning with real-world impact. The Municipality 16+ partnership co-created the game with educators, municipalities, and young changemakers across Europe to make civic participation tangible, collaborative, and fun.",
       "pillarOneTitle": "Game-based learning",
@@ -45,27 +50,19 @@
       "ctaTitle": "Ready to bring Municipio to your community?",
       "ctaText": "Start with the digital app or download the facilitation toolkit to run your own Municipio lab.",
       "ctaAppLink": "Launch the app",
-      "ctaDownloadLink": "Get the download pack",
       "footerText": "A Municipality 16+ collaboration powered by nvias.org and partners across Europe.",
       "footerAppLink": "Municipio web application",
-      "footerDownloadLink": "Downloadable resources",
       "footerContactLink": "Contact the team"
     },
     "cs": {
       "pageTitle": "Municipio – Spoluvytvářej své město",
-      "brandName": "Municipio",
       "footerBrandName": "Municipio",
-      "cardTitle": "Municipio",
-      "cardSubtitle": "Hraj | Uč se | Měň",
       "languageLabel": "Jazyk",
       "navAppLink": "Aplikace",
-      "navDownloadLink": "Ke stažení",
-      "tagline": "Spoluvytvářej své město",
       "heroEyebrow": "Hraj · Uč se · Měň",
       "heroTitle": "Municipio dává mladým lidem sílu přetvářet své okolí",
       "heroLead": "Municipio je desková hra a digitální nástroje, které školám i organizacím práce s mládeží pomáhají zkoumat občanské výzvy, navrhovat inkluzivní řešení a spolupracovat s komunitou.",
       "heroAppLink": "Otevřít webovou aplikaci",
-      "heroDownloadLink": "Stáhnout materiály",
       "aboutTitle": "O projektu",
       "aboutText": "Municipio propojuje hravé učení se skutečným dopadem. Partnerství Municipality 16+ vytvořilo hru společně s učiteli, městy a mladými inovátory po celé Evropě, aby byla občanská participace hmatatelná, spolupracující a zábavná.",
       "pillarOneTitle": "Učení hrou",
@@ -85,27 +82,19 @@
       "ctaTitle": "Připraveni přinést Municipio do své komunity?",
       "ctaText": "Začni digitální aplikací nebo si stáhni metodický balíček a zorganizuj vlastní Municipio lab.",
       "ctaAppLink": "Spustit aplikaci",
-      "ctaDownloadLink": "Získat balíček ke stažení",
       "footerText": "Spolupráce Municipality 16+ za podpory nvias.org a partnerů po celé Evropě.",
       "footerAppLink": "Webová aplikace Municipio",
-      "footerDownloadLink": "Materiály ke stažení",
       "footerContactLink": "Kontaktujte tým"
     },
     "lv": {
       "pageTitle": "Municipio – Līdzradī savu pilsētu",
-      "brandName": "Municipio",
       "footerBrandName": "Municipio",
-      "cardTitle": "Municipio",
-      "cardSubtitle": "Spēlē | Mācies | Pārveido",
       "languageLabel": "Valoda",
       "navAppLink": "Lietotne",
-      "navDownloadLink": "Lejupielādes",
-      "tagline": "Līdzradī savu pilsētu",
       "heroEyebrow": "Spēlē · Mācies · Pārveido",
       "heroTitle": "Municipio iedrošina jauniešus pārveidot savu apkārtni",
       "heroLead": "Municipio ir galda spēle un digitāls rīkkopums, kas palīdz skolām un jaunatnes organizācijām pētīt pilsoniskos izaicinājumus, veidot iekļaujošus risinājumus un sadarboties ar kopienām.",
       "heroAppLink": "Atvērt tīmekļa lietotni",
-      "heroDownloadLink": "Lejupielādēt materiālus",
       "aboutTitle": "Par projektu",
       "aboutText": "Municipio apvieno rotaļīgu mācīšanos ar reālu ietekmi. Municipality 16+ partnerība kopā ar pedagogiem, pašvaldībām un jaunajiem līderiem visā Eiropā radīja spēli, kas padara pilsonisko līdzdalību taustāmu, sadarbības pilnu un aizraujošu.",
       "pillarOneTitle": "Spēļmācība",
@@ -125,27 +114,19 @@
       "ctaTitle": "Gatavi ieviest Municipio savā kopienā?",
       "ctaText": "Sāc ar digitālo lietotni vai lejupielādē rīkkopu, lai vadītu savu Municipio darbnīcu.",
       "ctaAppLink": "Palaist lietotni",
-      "ctaDownloadLink": "Saņemt lejupielādes komplektu",
       "footerText": "Municipality 16+ sadarbība ar nvias.org un partneriem visā Eiropā.",
       "footerAppLink": "Municipio tīmekļa lietotne",
-      "footerDownloadLink": "Resursi lejupielādei",
       "footerContactLink": "Sazinies ar komandu"
     },
     "sl": {
       "pageTitle": "Municipio – Sooblikuj svoje mesto",
-      "brandName": "Municipio",
       "footerBrandName": "Municipio",
-      "cardTitle": "Municipio",
-      "cardSubtitle": "Igraj | Uči se | Spreminjaj",
       "languageLabel": "Jezik",
       "navAppLink": "Aplikacija",
-      "navDownloadLink": "Prenosi",
-      "tagline": "Sooblikuj svoje mesto",
       "heroEyebrow": "Igraj · Uči se · Spreminjaj",
       "heroTitle": "Municipio mladim daje orodja, da preoblikujejo svojo skupnost",
       "heroLead": "Municipio je namizna igra in digitalni komplet orodij, ki šolam ter mladinskim organizacijam pomaga raziskovati družbene izzive, soustvarjati vključujoče rešitve in graditi partnerstva v lokalnem okolju.",
       "heroAppLink": "Odpri spletno aplikacijo",
-      "heroDownloadLink": "Prenesi gradiva",
       "aboutTitle": "O projektu",
       "aboutText": "Municipio povezuje igrivo učenje z resničnim vplivom. Partnerstvo Municipality 16+ je skupaj z učitelji, občinami in mladimi ustvarjalci po vsej Evropi zasnovalo igro, ki omogoča oprijemljivo, sodelovalno in zabavno državljansko udejstvovanje.",
       "pillarOneTitle": "Učenje skozi igro",
@@ -165,10 +146,8 @@
       "ctaTitle": "Ste pripravljeni prinesti Municipio v svojo skupnost?",
       "ctaText": "Začnite s spletno aplikacijo ali prenesite paket za vodenje lastnega Municipio laboratorija.",
       "ctaAppLink": "Zaženi aplikacijo",
-      "ctaDownloadLink": "Prenesi paket gradiv",
       "footerText": "Partnerstvo Municipality 16+ v sodelovanju z nvias.org in partnerji po Evropi.",
       "footerAppLink": "Spletna aplikacija Municipio",
-      "footerDownloadLink": "Gradiva za prenos",
       "footerContactLink": "Kontaktiraj ekipo"
     }
   }

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -6,19 +6,13 @@ let languages = [];
 
 const textElements = {
   pageTitle: document.querySelector('title'),
-  brandName: document.getElementById('brandName'),
   footerBrandName: document.getElementById('footerBrandName'),
-  cardTitle: document.getElementById('cardTitle'),
-  cardSubtitle: document.getElementById('cardSubtitle'),
   languageLabel: document.getElementById('language-label'),
   navAppLink: document.getElementById('navAppLink'),
-  navDownloadLink: document.getElementById('navDownloadLink'),
-  tagline: document.getElementById('tagline'),
   heroEyebrow: document.getElementById('heroEyebrow'),
   heroTitle: document.getElementById('heroTitle'),
   heroLead: document.getElementById('heroLead'),
   heroAppLink: document.getElementById('heroAppLink'),
-  heroDownloadLink: document.getElementById('heroDownloadLink'),
   aboutTitle: document.getElementById('aboutTitle'),
   aboutText: document.getElementById('aboutText'),
   pillarOneTitle: document.getElementById('pillarOneTitle'),
@@ -38,22 +32,16 @@ const textElements = {
   ctaTitle: document.getElementById('ctaTitle'),
   ctaText: document.getElementById('ctaText'),
   ctaAppLink: document.getElementById('ctaAppLink'),
-  ctaDownloadLink: document.getElementById('ctaDownloadLink'),
   footerText: document.getElementById('footerText'),
   footerAppLink: document.getElementById('footerAppLink'),
-  footerDownloadLink: document.getElementById('footerDownloadLink'),
   footerContactLink: document.getElementById('footerContactLink'),
 };
 
 const linkElements = [
   document.getElementById('navAppLink'),
-  document.getElementById('navDownloadLink'),
   document.getElementById('heroAppLink'),
-  document.getElementById('heroDownloadLink'),
   document.getElementById('ctaAppLink'),
-  document.getElementById('ctaDownloadLink'),
   document.getElementById('footerAppLink'),
-  document.getElementById('footerDownloadLink'),
   document.getElementById('footerContactLink'),
 ];
 

--- a/public/index.html
+++ b/public/index.html
@@ -17,11 +17,7 @@
     <header class="hero">
       <nav class="top-nav">
         <div class="brand">
-          <span class="brand-emblem">M</span>
-          <div>
-            <strong id="brandName"></strong>
-            <small id="tagline"></small>
-          </div>
+          <img class="brand-logo" src="assets/img/title_Municipo.svg" alt="Municipio" />
         </div>
         <div class="nav-actions">
           <label class="language-selector">
@@ -30,7 +26,6 @@
             </select>
           </label>
           <a class="button ghost" id="navAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a>
-          <a class="button" id="navDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a>
         </div>
       </nav>
 
@@ -41,25 +36,9 @@
           <p class="hero-lead" id="heroLead"></p>
           <div class="hero-actions">
             <a class="button" id="heroAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a>
-            <a class="button ghost" id="heroDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a>
           </div>
         </div>
-        <div class="hero-visual" aria-hidden="true">
-          <div class="hero-card">
-            <div class="card-top">
-              <span class="card-title" id="cardTitle"></span>
-              <span class="card-subtitle" id="cardSubtitle"></span>
-            </div>
-            <div class="city-grid">
-              <span class="pin park"></span>
-              <span class="pin lab"></span>
-              <span class="pin school"></span>
-              <span class="pin hub"></span>
-              <span class="pin house"></span>
-              <span class="pin library"></span>
-            </div>
-          </div>
-        </div>
+        <div class="hero-visual" aria-hidden="true"></div>
       </div>
     </header>
 
@@ -119,7 +98,6 @@
           </div>
           <div class="cta-actions">
             <a class="button light" id="ctaAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a>
-            <a class="button outline" id="ctaDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a>
           </div>
         </div>
       </section>
@@ -133,7 +111,6 @@
         </div>
         <ul class="footer-links">
           <li><a id="footerAppLink" href="https://example.com/app" target="_blank" rel="noopener"></a></li>
-          <li><a id="footerDownloadLink" href="https://drive.google.com" target="_blank" rel="noopener"></a></li>
           <li><a id="footerContactLink" href="mailto:info@municipio.eu"></a></li>
         </ul>
       </div>


### PR DESCRIPTION
### Motivation
- Remove the colored pin/rectangle visuals from the hero so the header visual is clean and focuses on the background artwork.  
- Clean up leftover styles, markup and copy that referenced the removed hero card and downloadable materials.  
- Improve brand visibility by switching the textual emblem to the SVG logo and increasing its visual size.  

### Description
- Removed the hero pin grid markup and the `.hero-card` block from `public/index.html` and left an empty `.hero-visual` container.  
- Deleted the pin/grid/card styles (all `.hero-card`, `.card-top`, `.city-grid`, `.pin` rules) and adjusted hero overlay rules in `public/assets/css/styles.css`.  
- Replaced the textual brand emblem with an image `img.brand-logo` in `public/index.html` and added a `brand-logo` rule to `public/assets/css/styles.css` to enlarge and drop-shadow the logo.  
- Removed download-related entries and unused copy from `public/assets/data/content.json` and pruned corresponding DOM bindings in `public/assets/js/main.js`.  

### Testing
- Launched a local static server with `python -m http.server 4173 -d /workspace/nvias-municipality-16-landingpage/public` and it served the site successfully.  
- Ran a Playwright script to capture a full-page screenshot and produced `artifacts/municipio-hero-no-pins.png`, confirming the hero no longer shows the colored pin rectangles.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69662669033883298dd81c81f4cde929)